### PR TITLE
fix threading crash on reconnect

### DIFF
--- a/src/Xabbo/ViewModels/GameData/Texts/ExternalTextsViewModel.cs
+++ b/src/Xabbo/ViewModels/GameData/Texts/ExternalTextsViewModel.cs
@@ -1,25 +1,31 @@
 using System.Reactive.Linq;
 
 using Xabbo.Core.GameData;
+using Xabbo.Services.Abstractions;
 
 namespace Xabbo.ViewModels;
 
 public sealed class ExternalTextsViewModel : KeyValuesViewModel
 {
     private readonly IGameDataManager _gameDataManager;
+    private readonly IUiContext _uiContext;
 
-    public ExternalTextsViewModel(IGameDataManager gameDataManager)
+    public ExternalTextsViewModel(IGameDataManager gameDataManager, IUiContext uiContext)
     {
         _gameDataManager = gameDataManager;
+        _uiContext = uiContext;
         gameDataManager.Loaded += OnGameDataLoaded;
     }
 
     private void OnGameDataLoaded()
     {
-        Cache.Edit(cache => {
-            cache.Clear();
-            if (_gameDataManager.Texts is { } texts)
-                cache.AddOrUpdate(texts.Select(x => new KeyValueViewModel(x.Key, x.Value)));
+        _uiContext.Invoke(() =>
+        {
+            Cache.Edit(cache => {
+                cache.Clear();
+                if (_gameDataManager.Texts is { } texts)
+                    cache.AddOrUpdate(texts.Select(x => new KeyValueViewModel(x.Key, x.Value)));
+            });
         });
     }
 }

--- a/src/Xabbo/ViewModels/GameData/Variables/ExternalVariablesViewModel.cs
+++ b/src/Xabbo/ViewModels/GameData/Variables/ExternalVariablesViewModel.cs
@@ -1,25 +1,31 @@
 using System.Reactive.Linq;
 
 using Xabbo.Core.GameData;
+using Xabbo.Services.Abstractions;
 
 namespace Xabbo.ViewModels;
 
 public sealed class ExternalVariablesViewModel : KeyValuesViewModel
 {
     private readonly IGameDataManager _gameDataManager;
+    private readonly IUiContext _uiContext;
 
-    public ExternalVariablesViewModel(IGameDataManager gameDataManager)
+    public ExternalVariablesViewModel(IGameDataManager gameDataManager, IUiContext uiContext)
     {
         _gameDataManager = gameDataManager;
+        _uiContext = uiContext;
         gameDataManager.Loaded += OnGameDataLoaded;
     }
 
     private void OnGameDataLoaded()
     {
-        Cache.Edit(cache => {
-            cache.Clear();
-            if (_gameDataManager.Variables is { } vars)
-                cache.AddOrUpdate(vars.Select(x => new KeyValueViewModel(x.Key, x.Value)));
+        _uiContext.Invoke(() =>
+        {
+            Cache.Edit(cache => {
+                cache.Clear();
+                if (_gameDataManager.Variables is { } vars)
+                    cache.AddOrUpdate(vars.Select(x => new KeyValueViewModel(x.Key, x.Value)));
+            });
         });
     }
 }


### PR DESCRIPTION
ExternalVariablesViewModel and ExternalTextsViewModel were updating UI collections from a background thread when game data loads, causing Avalonia to crash.